### PR TITLE
Reduced retry max attempt for the digicert's get_certificate_id function

### DIFF
--- a/lemur/plugins/lemur_digicert/plugin.py
+++ b/lemur/plugins/lemur_digicert/plugin.py
@@ -234,7 +234,7 @@ def handle_cis_response(response):
         return response.json()
 
 
-@retry(stop_max_attempt_number=10, wait_fixed=1000)
+@retry(stop_max_attempt_number=5, wait_fixed=1000)
 def get_certificate_id(session, base_url, order_id):
     """Retrieve certificate order id from Digicert API."""
     order_url = "{0}/services/v2/order/certificate/{1}".format(base_url, order_id)


### PR DESCRIPTION
Decreased the max retry attempts for the digicert's plugin get_certificate_id function for avoiding to hit rate limiting at Digicert API.
Because the function is called frequently from celery tasks which are trying to resolve pending certificates