### PR TITLE
Hexify serial number in generate_gcp_certificate_name

### DIFF
--- a/lemur/common/defaults.py
+++ b/lemur/common/defaults.py
@@ -36,13 +36,14 @@ def generate_gcp_certificate_name(common_name, not_after, serial):
     """
     short_name = common_name.replace('*.', '').replace('.','-').lower()[:46]
     not_after = not_after.strftime("%Y%m%d")
+    short_serial = hex(int(serial))[2:].upper()[-6:] if serial else ""
 
-    certificate_name = f"{short_name}-{not_after}-{serial[-6:]}".rstrip("-")
+    certificate_name = f"{short_name}-{not_after}-{short_serial}".rstrip("-")
     
     return certificate_name
 
 
-def certificate_name(common_name, issuer, not_before, not_after, san, serial=""):
+def certificate_name(common_name, issuer, not_before, not_after, san, serial=None):
     """
     Create a name for our certificate. A naming standard
     is based on a series of templates. The name includes

--- a/lemur/tests/test_defaults.py
+++ b/lemur/tests/test_defaults.py
@@ -91,9 +91,9 @@ def test_generate_gcp_certificate_name(client, use_gcp_certificate_names):
         datetime(2015, 5, 12, 0, 0, 0),
         datetime(2015, 5, 12, 0, 0, 0),
         False,
-        "236713374230DEADBEEF"
+        123456789,
     )
-    assert cert_name == "www-example-com-20150512-ADBEEF"
+    assert cert_name == "www-example-com-20150512-5BCD15"
     assert matcher.match(cert_name)
 
     cert_name = certificate_name(
@@ -102,10 +102,10 @@ def test_generate_gcp_certificate_name(client, use_gcp_certificate_names):
         datetime(2015, 5, 12, 0, 0, 0),
         datetime(2015, 5, 12, 0, 0, 0),
         False,
-        "236713374230DEADBEEF"
+        123456789,
     )
 
-    assert cert_name == "example-com-20150512-ADBEEF"
+    assert cert_name == "example-com-20150512-5BCD15"
     assert matcher.match(cert_name)
 
     cert_name = certificate_name(
@@ -114,9 +114,9 @@ def test_generate_gcp_certificate_name(client, use_gcp_certificate_names):
         datetime(2121, 5, 12, 0, 0, 0),
         datetime(2121, 5, 12, 0, 0, 0),
         False,
-        "236713374230DEADBEEF"
+        123456,
     )
-    assert cert_name == "subdomain-subdomain-subdomain-subdomain-subdom-21210512-ADBEEF"
+    assert cert_name == "subdomain-subdomain-subdomain-subdomain-subdom-21210512-1E240"
     assert matcher.match(cert_name)
 
 


### PR DESCRIPTION
The parsed serial number is an int so we need to hexify it first.

https://cryptography.io/en/latest/x509/reference.html?highlight=serial_number#cryptography.x509.Certificate.serial_number

(Hexify code taken from the get_or_increase name function in certificates/model.py.)