### PR TITLE
Change to association object and update event

### DIFF
--- a/lemur/certificates/models.py
+++ b/lemur/certificates/models.py
@@ -439,13 +439,13 @@ class Certificate(db.Model):
 
 
 @event.listens_for(CertificateDestination, "after_insert")
-def update_destinations(target, value, certificate_destination):
+def update_destinations(mapper, connection, certificate_destination):
     """
     Attempt to upload certificate to the new destination
 
-    :param target:
-    :param value:
-    :param initiator:
+    :param mapper:
+    :param connection:
+    :param certificate_destination:
     :return:
     """
 

--- a/lemur/certificates/models.py
+++ b/lemur/certificates/models.py
@@ -23,6 +23,7 @@ from sqlalchemy import (
     Boolean,
     Index,
 )
+from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql.expression import case, extract
@@ -38,7 +39,7 @@ from lemur.extensions import sentry
 from lemur.models import (
     certificate_associations,
     certificate_source_associations,
-    certificate_destination_associations,
+    CertificateDestination,
     certificate_notification_associations,
     certificate_replacement_associations,
     roles_certificates,
@@ -159,11 +160,9 @@ class Certificate(db.Model):
         secondary=certificate_notification_associations,
         backref="certificate",
     )
-    destinations = relationship(
-        "Destination",
-        secondary=certificate_destination_associations,
-        backref="certificate",
-    )
+    destinations = association_proxy("certificate_destinations", "destination",
+                                     creator=lambda destination: CertificateDestination(destination=destination))
+
     sources = relationship(
         "Source", secondary=certificate_source_associations, backref="certificate"
     )
@@ -439,8 +438,8 @@ class Certificate(db.Model):
         return "Certificate(name={name})".format(name=self.name)
 
 
-@event.listens_for(Certificate.destinations, "append")
-def update_destinations(target, value, initiator):
+@event.listens_for(CertificateDestination, "after_insert")
+def update_destinations(target, value, certificate_destination):
     """
     Attempt to upload certificate to the new destination
 
@@ -449,31 +448,35 @@ def update_destinations(target, value, initiator):
     :param initiator:
     :return:
     """
-    destination_plugin = plugins.get(value.plugin_name)
+
+    cert = certificate_destination.certificate
+    dest = certificate_destination.destination
+
+    destination_plugin = plugins.get(dest.plugin_name)
     status = FAILURE_METRIC_STATUS
 
-    if target.expired:
+    if cert.expired:
         return
 
     if current_app.config.get("USE_ASYNCHRONOUS_DESTINATION_UPLOAD", False):
         current_app.logger.debug("Creating celery task to upload certificate to destination", extra={
-            "certificate_id": target.id,
-            "destination_id": value.id,
+            "certificate_id": cert.id,
+            "destination_id": dest.id,
         })
 
         # need to import it here due to cyclic dependencies
         from lemur.common.celery import certificate_check_destination
-        certificate_check_destination.apply_async((target.id, value.id), countdown=5)
+        certificate_check_destination.apply_async((cert.id, dest.id), countdown=5)
         return
 
     try:
-        if target.private_key or not destination_plugin.requires_key:
+        if cert.private_key or not destination_plugin.requires_key:
             destination_plugin.upload(
-                target.name,
-                target.body,
-                target.private_key,
-                target.chain,
-                value.options,
+                cert.name,
+                cert.body,
+                cert.private_key,
+                cert.chain,
+                dest.options,
             )
             status = SUCCESS_METRIC_STATUS
     except Exception as e:
@@ -486,8 +489,8 @@ def update_destinations(target, value, initiator):
         1,
         metric_tags={
             "status": status,
-            "certificate": target.name,
-            "destination": value.label,
+            "certificate": cert.name,
+            "destination": dest.label,
         },
     )
 

--- a/lemur/destinations/service.py
+++ b/lemur/destinations/service.py
@@ -9,7 +9,7 @@ from sqlalchemy import func
 from flask import current_app
 
 from lemur import database
-from lemur.models import certificate_destination_associations
+from lemur.models import CertificateDestination
 from lemur.destinations.models import Destination
 from lemur.certificates.models import Certificate
 from lemur.sources.service import add_aws_destination_to_sources
@@ -136,9 +136,9 @@ def stats(**kwargs):
     items = (
         database.db.session.query(
             Destination.label,
-            func.count(certificate_destination_associations.c.certificate_id),
+            func.count(CertificateDestination.certificate_id),
         )
-        .join(certificate_destination_associations)
+        .join(CertificateDestination)
         .group_by(Destination.label)
         .all()
     )

--- a/lemur/models.py
+++ b/lemur/models.py
@@ -9,6 +9,7 @@
 .. moduleauthor:: Kevin Glisson <kglisson@netflix.com>
 """
 from sqlalchemy import Column, Integer, ForeignKey, Index, UniqueConstraint
+from sqlalchemy.orm import relationship, backref
 
 from lemur.database import db
 
@@ -24,20 +25,19 @@ Index(
     certificate_associations.c.certificate_id,
 )
 
-certificate_destination_associations = db.Table(
-    "certificate_destination_associations",
-    Column(
-        "destination_id", Integer, ForeignKey("destinations.id", ondelete="cascade")
-    ),
-    Column(
-        "certificate_id", Integer, ForeignKey("certificates.id", ondelete="cascade")
-    ),
-)
+class CertificateDestination(db.Model):
+    __tablename__ = "certificate_destination_associations"
+    destination_id = Column(Integer, ForeignKey("destinations.id", ondelete="cascade"), primary_key=True)
+    certificate_id = Column(Integer, ForeignKey("certificates.id", ondelete="cascade"), primary_key=True)
+
+    destination = relationship("Destination", backref=backref("destination_certificates", cascade="all, delete-orphan"))
+    certificate = relationship("Certificate", backref=backref("certificate_destinations", cascade="all, delete-orphan"))
+
 
 Index(
     "certificate_destination_associations_ix",
-    certificate_destination_associations.c.destination_id,
-    certificate_destination_associations.c.certificate_id,
+    CertificateDestination.destination_id,
+    CertificateDestination.certificate_id,
 )
 
 certificate_source_associations = db.Table(


### PR DESCRIPTION
The event "append" did not contain certificate id / destination id when creating new certs (probably since the event is fired before the certificate is inserted into the database).

We looked for an  "after_append" but couldn't find anything that seemed to work the way we wanted, and just using "after_insert" on a regular association table wasn't supported.

This PR:
- Replaces the "association table" with an association object.
- Updates the event to fire on "after_insert" on the association object.