### PR TITLE
Change error handling logic if the endpoint is not exist in case of the endpoint rotation

### DIFF
--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -1201,7 +1201,7 @@ def rotate_endpoint(endpoint_id):
     endpoint = endpoint_service.get(endpoint_id)
 
     if not endpoint:
-        raise RuntimeError("endpoint did not exist")
+        logger.info(f"Skipping rotation,due to {endpoint_id} did not exist")
 
     old_certificate_id = endpoint.certificate.id
 

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -1202,6 +1202,7 @@ def rotate_endpoint(endpoint_id):
 
     if not endpoint:
         logger.info(f"Skipping rotation,due to {endpoint_id} did not exist")
+        return
 
     old_certificate_id = endpoint.certificate.id
 


### PR DESCRIPTION
## Summary
Logging the fact if the endpoint was not found instead of throw error during the rotate endpoint task.

### Details
If we are not receiving back endpoint during the rotate_endpoint, it is fine. Because it means the endpoint was removed earlier and we don't need to rotate the certificate on the endpoint.
