### PR TITLE
Fix pending certificate authority issue

### DIFF
--- a/lemur/pending_certificates/service.py
+++ b/lemur/pending_certificates/service.py
@@ -114,6 +114,7 @@ def create_certificate(pending_certificate, certificate, user):
     data["roles"] = list(pending_certificate.roles)
     data["replaces"] = list(pending_certificate.replaces)
     data["rotation_policy"] = pending_certificate.rotation_policy
+    data["authority"] = pending_certificate.authority
 
     # Replace external id and chain with the one fetched from source
     data["external_id"] = certificate["external_id"]

--- a/lemur/tests/conf.py
+++ b/lemur/tests/conf.py
@@ -202,6 +202,8 @@ ACME_TEL = "4088675309"
 ACME_DIRECTORY_URL = "https://acme-v01.api.letsencrypt.org"
 ACME_DISABLE_AUTORESOLVE = True
 
+DISABLE_AUTORESOLVE_NON_ACME = True
+
 LDAP_AUTH = True
 LDAP_BIND_URI = "ldap://localhost"
 LDAP_BASE_DN = "dc=example,dc=com"

--- a/lemur/tests/test_pending_certificates.py
+++ b/lemur/tests/test_pending_certificates.py
@@ -56,6 +56,7 @@ def test_create_pending(pending_certificate, user, session):
     assert real_cert.private_key == pending_certificate.private_key
     assert real_cert.external_id == "54321"
     assert real_cert.key_type == "RSA2048"
+    assert real_cert.authority_id == pending_certificate.authority_id
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Set authority on certificates created from pending certificates.

This is an issue with certs created from pending certificates, since the data is copied from the pending certificate using `vars` relationships does not get copied over automatically, instead they have to be explicitly set. Currently, the relationship `authority` is missing from the list of explicitly copied over relationships.

