### PR TITLE
Match existing certs on name and body only when importing sources

### DIFF
--- a/lemur/sources/service.py
+++ b/lemur/sources/service.py
@@ -172,28 +172,21 @@ def sync_endpoints(source):
 
 
 def find_cert(certificate):
-    exists = False
-
-    # if certificate.get("search", None):
-    #     conditions = certificate.pop("search")
-    #     exists = certificate_service.get_by_attributes(conditions)
-
-    if not exists and certificate.get("name"):
-        result = certificate_service.get_by_name(certificate["name"])
-        if result:
-            exists = [result]
-
-    # if not exists and certificate.get("serial"):
-    #     exists = certificate_service.get_by_serial(certificate["serial"])
-
-    if not exists:
+    if not certificate.get("name"):
+        # certificate must have a name
         return False, 0
 
-    # filter out certs that does not match by hash
+    matched_cert = certificate_service.get_by_name(certificate["name"])
+    if not matched_cert:
+        # no cert with the same name found
+        return False, 0
+
+    # check hash of matched cert
     cert = parse_certificate(certificate["body"])
-    exists = find_matching_certificates_by_hash(cert, exists)
+    exists = find_matching_certificates_by_hash(cert, [matched_cert])
     if not exists:
-        raise Exception("Name already taken!")
+        raise Exception("A certificate with the same name already exists with a different hash")
+
     return exists, len(exists)
 
 

--- a/lemur/sources/service.py
+++ b/lemur/sources/service.py
@@ -172,29 +172,29 @@ def sync_endpoints(source):
 
 
 def find_cert(certificate):
-    updated_by_hash = 0
     exists = False
 
-    if certificate.get("search", None):
-        conditions = certificate.pop("search")
-        exists = certificate_service.get_by_attributes(conditions)
+    # if certificate.get("search", None):
+    #     conditions = certificate.pop("search")
+    #     exists = certificate_service.get_by_attributes(conditions)
 
     if not exists and certificate.get("name"):
         result = certificate_service.get_by_name(certificate["name"])
         if result:
             exists = [result]
 
-    if not exists and certificate.get("serial"):
-        exists = certificate_service.get_by_serial(certificate["serial"])
+    # if not exists and certificate.get("serial"):
+    #     exists = certificate_service.get_by_serial(certificate["serial"])
 
     if not exists:
-        cert = parse_certificate(certificate["body"])
-        matching_serials = certificate_service.get_by_serial(serial(cert))
-        exists = find_matching_certificates_by_hash(cert, matching_serials)
-        updated_by_hash += 1
+        return False, 0
 
-    exists = [x for x in exists if x]
-    return exists, updated_by_hash
+    # filter out certs that does not match by hash
+    cert = parse_certificate(certificate["body"])
+    exists = find_matching_certificates_by_hash(cert, exists)
+    if not exists:
+        raise Exception("Name already taken!")
+    return exists, len(exists)
 
 
 # TODO this is very slow as we don't batch update certificates

--- a/lemur/tests/conftest.py
+++ b/lemur/tests/conftest.py
@@ -284,6 +284,16 @@ def source_plugin():
 
 
 @pytest.fixture(scope="function")
+def sync_source_plugin():
+    from lemur.plugins.base import register, unregister
+    from .plugins.source_plugin import TestSourcePlugin
+
+    register(TestSourcePlugin)
+    yield TestSourcePlugin
+    unregister(TestSourcePlugin)
+
+
+@pytest.fixture(scope="function")
 def logged_in_user(session, app):
     with app.test_request_context():
         identity_changed.send(current_app._get_current_object(), identity=Identity(1))

--- a/lemur/tests/plugins/source_plugin.py
+++ b/lemur/tests/plugins/source_plugin.py
@@ -12,8 +12,10 @@ class TestSourcePlugin(SourcePlugin):
     def __init__(self, *args, **kwargs):
         super(TestSourcePlugin, self).__init__(*args, **kwargs)
 
-    def get_certificates(self):
-        return
+        self.certificates = []
+
+    def get_certificates(self, *args, **kwargs):
+        return self.certificates
 
     def update_endpoint(self, endpoint, certificate):
         return

--- a/lemur/tests/test_sources.py
+++ b/lemur/tests/test_sources.py
@@ -67,7 +67,7 @@ def test_sync_certificates_same_cert_different_name(user, source, sync_source_pl
 
     res = sync_certificates(source, user["user"])
 
-    assert res == (1, 0, 1)
+    assert res == (1, 0, 0)
     assert cert_service.get_by_name("WildcardCert1") is not None
 
 
@@ -97,7 +97,7 @@ def test_sync_certificates_same_cert_same_name(user, source, sync_source_plugin)
 
     res = sync_certificates(source, user["user"])
 
-    assert res == (0, 1, 0)
+    assert res == (0, 1, 1)
     assert cert_service.get_by_name("WildcardCert2") is not None
 
 

--- a/lemur/tests/test_sources.py
+++ b/lemur/tests/test_sources.py
@@ -97,7 +97,7 @@ def test_sync_certificates_same_cert_same_name(user, source, sync_source_plugin)
 
     res = sync_certificates(source, user["user"])
 
-    assert res == (0, 1, 1)
+    assert res == (0, 1, 0)
     assert cert_service.get_by_name("WildcardCert2") is not None
 
 

--- a/lemur/tests/test_sources.py
+++ b/lemur/tests/test_sources.py
@@ -101,7 +101,7 @@ def test_sync_certificates_same_cert_same_name(user, source, sync_source_plugin)
     assert cert_service.get_by_name("WildcardCert2") is not None
 
 
-def test_sync_certificates_same_name_different_cert(user, source, sync_source_plugin):
+def test_sync_certificates_different_cert_existing_name(user, source, sync_source_plugin):
     from lemur.sources.service import sync_certificates, certificate_create
     from lemur.certificates import service as cert_service
     from lemur.plugins.base import plugins


### PR DESCRIPTION
This PR updates the find_cert function when importing certificates from a source plugin to only look at (name, certificate hash)-pairs.

Problems with the current solution:
- find_match will match any certificate based on search attributes, name or serial - even if the certificate hash is not the same.
- certificate names are set by the source plugins, matching different certificates on names could lead to incorrect rotations, potentially rotating in an expired or invalid certificate for endpoints it is currently attached to.
- certificate names are used by the GCP source plugin to know which certificate to remove from a load balancer, having this mapped to the same certificate but with a different name in Lemur would lead to rotations not finding the correct certificate.