### PR TITLE
Use floor and ceiling to get whole days.

### DIFF
--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -735,10 +735,10 @@ def calculate_reissue_range(start, end):
     """
     span = end - start
 
-    new_start = arrow.utcnow()
+    new_start = arrow.utcnow().floor("day")
     new_end = new_start + span
 
-    return new_start, arrow.get(new_end)
+    return new_start, arrow.get(new_end).ceil("day")
 
 
 def get_certificate_primitives(certificate):


### PR DESCRIPTION
This should stop the drift we see in auto-rotated certs.