### PR TITLE
Ensure checking task status doesn't unecessarily raise an exception

### DIFF
--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -79,6 +79,10 @@ def is_task_active(fun, task_id, args):
 
     i = inspect()
     active_tasks = i.active()
+
+    if active_tasks is None:
+        return False
+
     for _, tasks in active_tasks.items():
         for task in tasks:
             if task.get("id") == task_id:


### PR DESCRIPTION
Based of off https://github.com/Netflix/lemur/commit/b8d1b956640d89a8643070f8eb184ff0aa235b88 as we saw the same issue internally