### PR TITLE
configure celery broker to health check redis

### DIFF
--- a/lemur/default.conf.py
+++ b/lemur/default.conf.py
@@ -16,3 +16,10 @@ DEBUG = False
 
 LOG_LEVEL = "DEBUG"
 LOG_FILE = "lemur.log"
+
+# Celery
+
+broker_transport_options = {
+    # Check the health of connections every 5 seconds
+    'health_check_interval': 5,
+}  


### PR DESCRIPTION
this might solve one of the issues we see when our redis pod restarts https://github.com/celery/kombu/issues/1019