### PR TITLE
Update README for Spotify fork

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,41 +1,27 @@
-Lemur
-=====
+Lemur (Spotify fork)
+====================
 
-.. warning::
+.. note::
 
-   This repository is now archived and read-only as of July 6, 2026.
+   This is Spotify's maintained fork of `Netflix/lemur <https://github.com/Netflix/lemur>`_,
+   which was archived on July 6, 2026.
 
-   No new pull requests, issues, or contributions will be accepted. Existing content will remain available and publicly accessible, but this repository is no longer actively maintained. If you need to continue making changes, please fork this repository.
+   We use Lemur internally for TLS certificate lifecycle management across our
+   edge infrastructure. This fork contains bug fixes and operational improvements
+   specific to our deployment. Community contributions are welcome.
 
-   Thank you to everyone who has contributed over the years.
-
-.. image:: https://badges.gitter.im/Join%20Chat.svg
-   :alt: Join the chat at https://gitter.im/Netflix/lemur
-   :target: https://gitter.im/Netflix/lemur?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
-
-.. image:: https://readthedocs.org/projects/lemur/badge/?version=latest
-    :target: https://lemur.readthedocs.io
-    :alt: Latest Docs
-
-.. image:: https://img.shields.io/badge/NetflixOSS-active-brightgreen.svg
-
-.. image:: https://coveralls.io/repos/github/Netflix/lemur/badge.svg?branch=main
-    :target: https://coveralls.io/github/Netflix/lemur?branch=main
-
+   The original Spotify fork (``master`` branch, pre-Netflix sync) is preserved
+   as the ``old_fork`` branch for reference.
 
 
 Lemur manages TLS certificate creation. While not able to issue certificates itself, Lemur acts as a broker between CAs
 and environments providing a central portal for developers to issue TLS certificates with 'sane' defaults.
 
-Lemur aims to support the 3 most recent python releases which have been released for at least a year. For example, if python3.14 released last month, we'd aim to support versions 3.10, 3.11, 3.12, and 3.13.
-We deploy on Ubuntu 22.04 and develop mostly on OS X.
-
 
 Project resources
 =================
 
-- `Lemur Blog Post <http://techblog.netflix.com/2015/09/introducing-lemur.html>`_
+- `Original Netflix Blog Post <http://techblog.netflix.com/2015/09/introducing-lemur.html>`_
 - `Documentation <http://lemur.readthedocs.io/>`_
-- `Source code <https://github.com/netflix/lemur>`_
-- `Issue tracker <https://github.com/netflix/lemur/issues>`_
-- `Docker <https://github.com/Netflix/lemur-docker>`_
+- `Upstream source (archived) <https://github.com/Netflix/lemur>`_
+- `Issue tracker <https://github.com/spotify/lemur/issues>`_


### PR DESCRIPTION
Netflix/lemur was archived on 2026-07-06. This fork is now maintained by Spotify for internal TLS certificate lifecycle management.

Changes:
- Replace Netflix archival notice with Spotify fork notice
- Remove stale Netflix badges (Gitter, NetflixOSS, Coveralls)
- Update project links (issue tracker → spotify/lemur, upstream marked as archived)
- Document branch layout (`main` = synced with Netflix final state, `old_fork` = original Spotify fork)